### PR TITLE
Fix index to load main.tsx

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load `main.tsx` instead of `main.jsx` in `index.html`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866f437c04c832f8828995c1a69bb6f

## Summary by Sourcery

Bug Fixes:
- Update index.html script tag to load main.tsx instead of main.jsx.