### PR TITLE
Fix missing module exports

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,8 +1,8 @@
 export * from './auth'
 export * from './users'
-export * from './models'
-export * from './checkout'
-export * from './favorites'
-export * from './filaments'
-export * from './upload'
+// export * from './models' // Module does not exist
+// export * from './checkout' // Module does not exist
+// export * from './favorites' // Module does not exist
+// export * from './filaments' // Module does not exist
+// export * from './upload' // Module does not exist
 export * from './estimate'


### PR DESCRIPTION
## Summary
- comment out exports in `src/api/index.ts` for modules that don't exist

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866f65ad4e8832fb59864ab955326ff

## Summary by Sourcery

Bug Fixes:
- Comment out exports for './models', './checkout', './favorites', './filaments', and './upload' which do not exist