### PR TITLE
Fix auth user update flow

### DIFF
--- a/src/api/authCallback.ts
+++ b/src/api/authCallback.ts
@@ -15,7 +15,7 @@ export async function handleAuthCallback(
 
     if (res.status === 200 && res.data?.token && res.data?.user) {
       useAuthStore.getState().setToken(res.data.token)
-      useAuthStore.getState().setUser(res.data.user, res.data.token)
+      useAuthStore.getState().setUser(res.data.user)
 
       localStorage.setItem("auth_token", res.data.token)
       console.debug("[AuthCallback] ✅ Token saved and user updated")

--- a/src/components/auth/AuthCallback.tsx
+++ b/src/components/auth/AuthCallback.tsx
@@ -26,7 +26,7 @@ const AuthCallback = () => {
         if (res.status === 200 && res.data?.token && res.data?.user) {
           const { token, user } = res.data
           useAuthStore.getState().setToken(token)
-          useAuthStore.getState().setUser(user, token)
+          useAuthStore.getState().setUser(user)
           localStorage.setItem("auth_token", token)
 
           console.info("[AuthCallback] ✅ Auth success. Redirecting to dashboard...")


### PR DESCRIPTION
## Summary
- fix usage of `setUser` in auth callback to avoid passing token
- adjust auth callback API helper

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866ff931758832fa4f36aa6aeb18359

## Summary by Sourcery

Fix the authentication callback flow by adjusting the setUser signature and ensuring only the user object is passed when updating auth state

Bug Fixes:
- Prevent passing the auth token into setUser to correct the user update flow

Enhancements:
- Simplify setUser calls by removing the redundant token argument in both the API helper and React component