### PR TITLE
Extend estimate store with form and result state

### DIFF
--- a/src/store/useEstimateStore.ts
+++ b/src/store/useEstimateStore.ts
@@ -8,14 +8,39 @@ export interface ModelEstimate {
   [key: string]: unknown
 }
 
+export interface EstimateForm {
+  x_mm: number | string
+  y_mm: number | string
+  z_mm: number | string
+  filament_type: 'pla' | 'petg'
+  print_profile: 'standard' | 'quality' | 'elite'
+}
+
+export interface EstimateResult {
+  estimated_time_minutes: number
+  estimated_cost_usd: number
+}
+
 interface EstimateStoreState {
   selectedModels: ModelEstimate[]
+  form: EstimateForm
+  result: EstimateResult | null
   setSelectedModels: (models: ModelEstimate[]) => void
   clearSelectedModels: () => void
+  setForm: <K extends keyof EstimateForm>(field: K, value: EstimateForm[K]) => void
+  setResult: (result: EstimateResult | null) => void
 }
 
 export const useEstimateStore = create<EstimateStoreState>((set) => ({
   selectedModels: [],
+  form: {
+    x_mm: '',
+    y_mm: '',
+    z_mm: '',
+    filament_type: 'pla',
+    print_profile: 'standard',
+  },
+  result: null,
 
   setSelectedModels: (models: ModelEstimate[]) => {
     console.debug('[useEstimateStore] setSelectedModels:', models)
@@ -25,5 +50,15 @@ export const useEstimateStore = create<EstimateStoreState>((set) => ({
   clearSelectedModels: () => {
     console.debug('[useEstimateStore] clearSelectedModels()')
     set({ selectedModels: [] })
+  },
+
+  setForm: (field, value) => {
+    console.debug('[useEstimateStore] setForm:', field, value)
+    set((state) => ({ form: { ...state.form, [field]: value } }))
+  },
+
+  setResult: (result) => {
+    console.debug('[useEstimateStore] setResult:', result)
+    set({ result })
   },
 }))


### PR DESCRIPTION
## Summary
- expand `useEstimateStore` to track estimate form fields
- add helpers to update form values and store API results

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686700c24cdc832fba060e4df5904b3b

## Summary by Sourcery

Extend the estimate store to manage form inputs and API results alongside selected models.

Enhancements:
- Define EstimateForm and EstimateResult interfaces for form data and API response
- Initialize form state and result state in the store with default values
- Add setForm and setResult actions to update form fields and persist estimate results