### PR TITLE
Add skeleton browse layout

### DIFF
--- a/src/components/ui/ModelCardSkeleton.tsx
+++ b/src/components/ui/ModelCardSkeleton.tsx
@@ -1,0 +1,11 @@
+import GlassCard from './GlassCard'
+
+export default function ModelCardSkeleton() {
+  return (
+    <GlassCard className="animate-pulse" padding="p-4">
+      <div className="w-full h-40 bg-zinc-300/50 dark:bg-zinc-700/50 rounded mb-4"></div>
+      <div className="h-4 bg-zinc-300/50 dark:bg-zinc-700/50 rounded w-3/4 mb-2"></div>
+      <div className="h-3 bg-zinc-300/50 dark:bg-zinc-700/50 rounded w-1/2"></div>
+    </GlassCard>
+  )
+}

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1,38 +1,79 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import PageLayout from '@/components/layout/PageLayout'
 import GlassCard from '@/components/ui/GlassCard'
+import GlassButton from '@/components/ui/GlassButton'
+import ModelCardSkeleton from '@/components/ui/ModelCardSkeleton'
 
 const Browse: React.FC = () => {
+  const [query, setQuery] = useState('')
+
   useEffect(() => {
     console.debug('[Browse] Component mounted')
-
-    // Placeholder for future model loading
-    console.debug('[Browse] Using static demo cards')
   }, [])
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault()
+    console.debug('[Browse] Search submitted:', query)
+  }
 
   return (
     <PageLayout title="Browse Models">
+      <GlassCard className="mb-6">
+        <form onSubmit={handleSearch} className="flex flex-col gap-2">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              placeholder="Search MakerWorks"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="glass-input flex-grow"
+            />
+            <GlassButton type="submit" size="sm">
+              Search
+            </GlassButton>
+          </div>
+          <div className="text-sm text-zinc-600 dark:text-zinc-400 flex flex-wrap gap-4">
+            <span>External Libraries:</span>
+            <a
+              href="https://www.thingiverse.com"
+              target="_blank"
+              rel="noreferrer"
+              className="hover:underline"
+            >
+              Thingiverse
+            </a>
+            <a
+              href="https://www.printables.com"
+              target="_blank"
+              rel="noreferrer"
+              className="hover:underline"
+            >
+              Printables
+            </a>
+            <a
+              href="https://thangs.com"
+              target="_blank"
+              rel="noreferrer"
+              className="hover:underline"
+            >
+              Thangs
+            </a>
+            <a
+              href="https://makerworld.com"
+              target="_blank"
+              rel="noreferrer"
+              className="hover:underline"
+            >
+              Makerworld
+            </a>
+          </div>
+        </form>
+      </GlassCard>
+
       <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-6">
-        <GlassCard>
-          <h2 className="text-lg font-semibold mb-2">Articulated Dragon</h2>
-          <p className="text-sm text-zinc-600 dark:text-zinc-400">
-            A flexible 3D printed dragon with articulating joints.
-          </p>
-        </GlassCard>
-
-        <GlassCard>
-          <h2 className="text-lg font-semibold mb-2">Cable Organizer</h2>
-          <p className="text-sm text-zinc-600 dark:text-zinc-400">
-            Clip-on cable holder with customizable length.
-          </p>
-        </GlassCard>
-
-        <GlassCard>
-          <h2 className="text-lg font-semibold mb-2">Mini Planter</h2>
-          <p className="text-sm text-zinc-600 dark:text-zinc-400">
-            Stylish desktop planter for succulents and small herbs.
-          </p>
-        </GlassCard>
+        {Array.from({ length: 6 }).map((_, i) => (
+          <ModelCardSkeleton key={i} />
+        ))}
       </div>
     </PageLayout>
   )


### PR DESCRIPTION
## Summary
- add a skeleton card component for browse page listings
- build out browse page with search bar and external library links

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68670adb13cc832f9fd88b167e058645