### PR TITLE
Fix default API base URL

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -7,8 +7,9 @@ import axios, {
   AxiosError,
 } from 'axios'
 
-const baseURL =
-  import.meta.env.VITE_API_BASE_URL?.replace(/\/+$/, '') || 'http://192.168.1.170:49152'
+const baseURL = (
+  import.meta.env.VITE_API_BASE_URL || 'http://localhost:5173'
+).replace(/\/+$/, '')
 
 console.debug('[Axios] Using API base URL:', baseURL)
 


### PR DESCRIPTION
## Summary
- update axios baseURL fallback to use localhost

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68670e1c1f7c832fa270a3d0044459c0