### PR TITLE
Add preview cleanup effect

### DIFF
--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -15,6 +15,15 @@ export default function Upload() {
   const [renderStatus, setRenderStatus] = useState<RenderStatus>(null)
   const dropzoneRef = useRef<HTMLDivElement | null>(null)
 
+  // Clean up preview URL when component unmounts or a new file is selected
+  useEffect(() => {
+    return () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl)
+      }
+    }
+  }, [previewUrl])
+
   const handleFileChange = (f: File) => {
     setFile(f)
     setPreviewUrl(URL.createObjectURL(f))


### PR DESCRIPTION
## Summary
- revoke preview URLs when component unmounts or new files are chosen

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68670eaada1c832fad2d94cf97586967