### PR TITLE
Fix useClickAway typing

### DIFF
--- a/src/hooks/useClickAway.ts
+++ b/src/hooks/useClickAway.ts
@@ -2,11 +2,11 @@
 import { useEffect, useRef } from 'react'
 
 const useClickAway = (onClickAway: () => void) => {
-  const ref = useRef(null)
+  const ref = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
-      if (ref.current && !(ref.current as any).contains(e.target)) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
         onClickAway()
       }
     }


### PR DESCRIPTION
## Summary
- type the click away ref with `useRef<HTMLElement | null>`
- remove `any` cast when checking containment

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68670f19ad14832f8685adcb9714b598