### PR TITLE
Add filament color support

### DIFF
--- a/src/pages/Estimate.tsx
+++ b/src/pages/Estimate.tsx
@@ -10,6 +10,7 @@ interface EstimateForm {
   y_mm: number | string
   z_mm: number | string
   filament_type: 'pla' | 'petg'
+  filament_color: string
   print_profile: 'standard' | 'quality' | 'elite'
 }
 
@@ -33,10 +34,12 @@ export default function Estimate() {
     setLoading(true)
     try {
       const payload = {
-        ...form,
         x_mm: parseFloat(form.x_mm as string),
         y_mm: parseFloat(form.y_mm as string),
         z_mm: parseFloat(form.z_mm as string),
+        filamentType: form.filament_type,
+        filamentColor: form.filament_color,
+        printProfile: form.print_profile,
       }
 
       console.debug('[Estimate] Sending payload to API:', payload)
@@ -98,6 +101,19 @@ export default function Estimate() {
                 <option value="pla">PLA</option>
                 <option value="petg">PETG</option>
               </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Filament Color</label>
+              <input
+                type="color"
+                value={form.filament_color}
+                onChange={(e) => {
+                  setForm('filament_color', e.target.value)
+                  console.debug('[Estimate] filament_color:', e.target.value)
+                }}
+                className="w-full rounded-md border p-2 h-10 dark:bg-zinc-800"
+              />
             </div>
 
             <div>

--- a/src/store/useEstimateStore.ts
+++ b/src/store/useEstimateStore.ts
@@ -13,6 +13,7 @@ export interface EstimateForm {
   y_mm: number | string
   z_mm: number | string
   filament_type: 'pla' | 'petg'
+  filament_color: string
   print_profile: 'standard' | 'quality' | 'elite'
 }
 
@@ -38,6 +39,7 @@ export const useEstimateStore = create<EstimateStoreState>((set) => ({
     y_mm: '',
     z_mm: '',
     filament_type: 'pla',
+    filament_color: '#ffffff',
     print_profile: 'standard',
   },
   result: null,


### PR DESCRIPTION
## Summary
- extend `EstimateForm` to include a `filament_color`
- show a color picker in the estimate page
- send `filamentType`, `filamentColor` and `printProfile` when requesting an estimate

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6867a4ee38f8832f9ed185b50f77048e

## Summary by Sourcery

Add filament color support to the Estimate page by extending the form, UI, store, and API payload.

New Features:
- Add a filament color field with a color picker in the Estimate form UI
- Send the selected filamentColor along with filamentType and printProfile in the estimate API request

Enhancements:
- Switch API payload construction to explicit field mappings and set a default filament color in the store state