### PR TITLE
Fix STL/3MF upload validation

### DIFF
--- a/src/pages/Uploads.tsx
+++ b/src/pages/Uploads.tsx
@@ -26,7 +26,8 @@ export default function Uploads() {
   }, [])
 
   const handleFileChange = (f: File) => {
-    if (!['model/stl', 'application/octet-stream'].includes(f.type) && !f.name.endsWith('.stl') && !f.name.endsWith('.3mf')) {
+    const lowerName = f.name.toLowerCase()
+    if (!['model/stl', 'application/octet-stream'].includes(f.type) && !lowerName.endsWith('.stl') && !lowerName.endsWith('.3mf')) {
       toast.error('Invalid file type. Only STL or 3MF allowed.')
       return
     }


### PR DESCRIPTION
## Summary
- fix upload extension check to be case-insensitive

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68685204111c832f96dcddaaf44a3f2c

## Summary by Sourcery

Bug Fixes:
- Make STL and 3MF file extension check case-insensitive.