### PR TITLE
Remove localStorage token persistence

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -2,6 +2,7 @@
 
 import axios from './axios'
 import { User } from '@/types/user'
+import { useAuthStore } from '@/store/useAuthStore'
 
 const BACKEND_LOGIN_URL = '/auth/login'
 const CURRENT_USER_URL = `/users/users/me`
@@ -42,7 +43,6 @@ export async function loginWithPassword(
     })
     const tokenData = res.data
     console.debug('[Auth] Received token via backend:', tokenData)
-    localStorage.setItem('token', tokenData.access_token)
     return tokenData
   } catch (err: any) {
     console.error('[Auth] Failed login via backend:', err)
@@ -75,5 +75,5 @@ export async function signup({
  * Clear auth token from storage.
  */
 export function logout() {
-  localStorage.removeItem('token')
+  useAuthStore.getState().logout()
 }

--- a/src/api/authCallback.ts
+++ b/src/api/authCallback.ts
@@ -16,8 +16,6 @@ export async function handleAuthCallback(
     if (res.status === 200 && res.data?.token && res.data?.user) {
       useAuthStore.getState().setToken(res.data.token)
       useAuthStore.getState().setUser(res.data.user)
-
-      localStorage.setItem("auth_token", res.data.token)
       console.debug("[AuthCallback] ✅ Token saved and user updated")
 
       navigate("/dashboard")

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -38,7 +38,6 @@ function parseAuthentikUser(): AuthentikUser | null {
 instance.interceptors.request.use((config: AxiosRequestConfig): AxiosRequestConfig => {
   try {
     const auth = parseAuthentikUser()
-    const token = sessionStorage.getItem('access_token')
 
     config.headers = {
       ...config.headers,
@@ -50,9 +49,6 @@ instance.interceptors.request.use((config: AxiosRequestConfig): AxiosRequestConf
       config.headers['X-Authentik-Groups'] = auth.groups?.join(',') || ''
     }
 
-    if (token) {
-      config.headers['Authorization'] = `Bearer ${token}`
-    }
 
     const label = `[REQ] ${config.method?.toUpperCase() || 'GET'} ${config.url}`
     console.debug(label)

--- a/src/components/auth/AuthCallback.tsx
+++ b/src/components/auth/AuthCallback.tsx
@@ -27,7 +27,6 @@ const AuthCallback = () => {
           const { token, user } = res.data
           useAuthStore.getState().setToken(token)
           useAuthStore.getState().setUser(user)
-          localStorage.setItem("auth_token", token)
 
           console.info("[AuthCallback] ✅ Auth success. Redirecting to dashboard...")
           return navigate("/dashboard")

--- a/src/components/auth/SignUp.tsx
+++ b/src/components/auth/SignUp.tsx
@@ -42,9 +42,6 @@ const SignUp: React.FC = () => {
         console.warn("[SignUp] ⚠️ setToken is not a function")
       }
 
-      // Optional: persist token
-      localStorage.setItem("token", token)
-
       // Navigate to dashboard
       navigate("/dashboard")
     } catch (err: any) {

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,6 +1,5 @@
 // src/store/useAuthStore.ts
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
 import axios from '@/api/axios'
 import type { User } from '@/types/user'
 
@@ -19,9 +18,7 @@ interface AuthState {
   __mockUser?: boolean // DEV ONLY
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set, get) => ({
+export const useAuthStore = create<AuthState>()((set, get) => ({
       user: null,
       token: null,
       loading: false,
@@ -107,13 +104,5 @@ export const useAuthStore = create<AuthState>()(
           set({ loading: false })
         }
       },
-    }),
-    {
-      name: 'auth-store',
-      partialize: (state) => ({
-        user: state.user,
-        token: state.token,
-      }),
-    }
-  )
+    })
 )


### PR DESCRIPTION
## Summary
- keep auth tokens only in memory via zustand store
- update login/signup callback handlers to not write localStorage
- rely on axios defaults for authorization header

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686852ceae38832fac19e37c5bb9b709

## Summary by Sourcery

Remove localStorage/sessionStorage token persistence and rely solely on in-memory zustand store and axios defaults for authorization

Enhancements:
- Remove persist wrapper from useAuthStore to disable automatic storage and keep tokens in memory
- Eliminate localStorage writes in login, signup, and auth callback handlers and update logout to clear tokens via the store
- Remove sessionStorage reads and manual Authorization header setup in axios interceptor to use axios defaults for auth header