### PR TITLE
Fix role checking via useUser

### DIFF
--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -36,6 +36,7 @@ export const useUser = () => {
     resolved,
     isAuthed: isAuthenticatedFn?.() ?? false,
     isAuthenticated: isAuthenticatedFn?.() ?? false,
+    hasRole: hasRoleFn,
     isAdmin,
     isUser,
   }


### PR DESCRIPTION
## Summary
- expose the `hasRole` helper from `useUser` so role checks work in `ProtectedLayout`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6868fd4088b8832facce5f36e530f93a