### PR TITLE
Add admin placeholder pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,10 @@ import Browse from '@/pages/Browse'
 import Uploads from '@/pages/Uploads'
 import Estimate from '@/pages/Estimate'
 import Admin from '@/pages/Admin'
+import AdminUsers from '@/pages/AdminUsers'
+import AdminModels from '@/pages/AdminModels'
+import AdminFilaments from '@/pages/AdminFilaments'
+import AdminSystem from '@/pages/AdminSystem'
 import Cart from '@/pages/Cart'
 import Checkout from '@/pages/Checkout'     // ✅ added
 import NotFound from '@/pages/NotFound'
@@ -89,6 +93,38 @@ function AnimatedRoutes() {
           element={
             <ProtectedAdminRoute>
               <Admin />
+            </ProtectedAdminRoute>
+          }
+        />
+        <Route
+          path="/admin/users"
+          element={
+            <ProtectedAdminRoute>
+              <AdminUsers />
+            </ProtectedAdminRoute>
+          }
+        />
+        <Route
+          path="/admin/models"
+          element={
+            <ProtectedAdminRoute>
+              <AdminModels />
+            </ProtectedAdminRoute>
+          }
+        />
+        <Route
+          path="/admin/filaments"
+          element={
+            <ProtectedAdminRoute>
+              <AdminFilaments />
+            </ProtectedAdminRoute>
+          }
+        />
+        <Route
+          path="/admin/system"
+          element={
+            <ProtectedAdminRoute>
+              <AdminSystem />
             </ProtectedAdminRoute>
           }
         />

--- a/src/pages/AdminFilaments.tsx
+++ b/src/pages/AdminFilaments.tsx
@@ -1,0 +1,11 @@
+import PageLayout from '@/components/layout/PageLayout'
+
+const AdminFilaments: React.FC = () => {
+  return (
+    <PageLayout title="Filament Pricing">
+      <p className="text-muted-foreground">Filament management coming soon.</p>
+    </PageLayout>
+  )
+}
+
+export default AdminFilaments

--- a/src/pages/AdminModels.tsx
+++ b/src/pages/AdminModels.tsx
@@ -1,0 +1,11 @@
+import PageLayout from '@/components/layout/PageLayout'
+
+const AdminModels: React.FC = () => {
+  return (
+    <PageLayout title="Model Library">
+      <p className="text-muted-foreground">Admin model library coming soon.</p>
+    </PageLayout>
+  )
+}
+
+export default AdminModels

--- a/src/pages/AdminSystem.tsx
+++ b/src/pages/AdminSystem.tsx
@@ -1,0 +1,11 @@
+import PageLayout from '@/components/layout/PageLayout'
+
+const AdminSystem: React.FC = () => {
+  return (
+    <PageLayout title="System Settings">
+      <p className="text-muted-foreground">System settings coming soon.</p>
+    </PageLayout>
+  )
+}
+
+export default AdminSystem

--- a/src/pages/AdminUsers.tsx
+++ b/src/pages/AdminUsers.tsx
@@ -1,0 +1,11 @@
+import PageLayout from '@/components/layout/PageLayout'
+
+const AdminUsers: React.FC = () => {
+  return (
+    <PageLayout title="User Management">
+      <p className="text-muted-foreground">Admin user management coming soon.</p>
+    </PageLayout>
+  )
+}
+
+export default AdminUsers


### PR DESCRIPTION
## Summary
- add placeholder pages for admin sections
- wire `/admin/users`, `/admin/models`, `/admin/filaments`, `/admin/system` routes

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868ffb9b4fc832fb564fb83682ae8c4

## Summary by Sourcery

Introduce placeholder pages for the admin panel and wire corresponding protected routes

New Features:
- Add AdminUsers, AdminModels, AdminFilaments, and AdminSystem placeholder pages with 'coming soon' messages
- Bind /admin/users, /admin/models, /admin/filaments, and /admin/system paths to their respective protected admin routes