### PR TITLE
Add missing imports in App

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,10 @@ import { toast } from 'sonner' // ✅ add sonner or your preferred toast lib
 
 // … [imports unchanged] …
 
+import Navbar from '@/components/layout/Navbar'
+import { ModalProvider } from '@/context/ModalProvider'
+import AnimatedRoutes from '@/components/AnimatedRoutes'
+
 import { useAuthStore } from '@/store/useAuthStore'
 
 const isDev = import.meta.env.MODE === 'development'


### PR DESCRIPTION
## Summary
- import Navbar, ModalProvider, and AnimatedRoutes in `src/App.tsx`

## Testing
- `npm test` *(fails: 4 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_686917e33928832f8c8f7e155059fb23

## Summary by Sourcery

Bug Fixes:
- Import Navbar, ModalProvider, and AnimatedRoutes into App.tsx to resolve missing references