### PR TITLE
Fix cart store tests

### DIFF
--- a/__tests__/useCartStore.test.ts
+++ b/__tests__/useCartStore.test.ts
@@ -15,6 +15,7 @@ describe('useCartStore', () => {
 
   it('increases quantity', () => {
     act(() => {
+      useCartStore.getState().addItem({ id: '1', name: 'Test', price: 10, quantity: 1 })
       useCartStore.getState().increaseQuantity('1')
     })
     expect(useCartStore.getState().items[0].quantity).toBe(2)
@@ -38,21 +39,24 @@ describe('useCartStore', () => {
 
   it('computes subtotal', () => {
     act(() => {
-      useCartStore.getState().addItem({ id: '3', name: 'Test3', price: 15, quantity: 2 })
+      useCartStore.getState().addItem({ id: '3', name: 'Test3', price: 15, quantity: 1 })
+      useCartStore.getState().setQuantity('3', 2)
     })
     expect(useCartStore.getState().subtotal()).toBe(30)
   })
 
   it('computes cart count', () => {
     act(() => {
-      useCartStore.getState().addItem({ id: '4', name: 'Test4', price: 5, quantity: 2 })
+      useCartStore.getState().addItem({ id: '4', name: 'Test4', price: 5, quantity: 1 })
+      useCartStore.getState().setQuantity('4', 2)
     })
     expect(useCartStore.getState().cartCount()).toBe(2)
   })
 
   it('computes subtotalCents (Stripe-ready)', () => {
     act(() => {
-      useCartStore.getState().addItem({ id: '5', name: 'Test5', price: 25, quantity: 2 })
+      useCartStore.getState().addItem({ id: '5', name: 'Test5', price: 25, quantity: 1 })
+      useCartStore.getState().setQuantity('5', 2)
     })
     expect(useCartStore.getState().subtotal() * 100).toBe(50 * 100)
   })


### PR DESCRIPTION
## Summary
- update cart store tests to add items before verifying quantities and subtotals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68691b4823b8832f97c9f0d6b48e2cb3