### PR TITLE
Extend modal interface

### DIFF
--- a/src/store/useModalStore.ts
+++ b/src/store/useModalStore.ts
@@ -1,9 +1,12 @@
 // src/store/useModalStore.ts
 import { create } from 'zustand'
+import type { ReactNode } from 'react'
 
 export type ModalType = 'example' | 'upload' | 'settings' | 'cart' | 'signin'
 
 type Modal = {
+  id: string
+  component: ReactNode
   type: ModalType
   props?: Record<string, unknown>
 }


### PR DESCRIPTION
## Summary
- update the `Modal` type to include `id` and `component`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a45f9497c832fa6386dd122cff0b4

## Summary by Sourcery

Extend the Modal interface in the zustand store to include an identifier and component payload

Enhancements:
- Import ReactNode and add a component property to the Modal type
- Add a unique id property to the Modal type for better modal management