### PR TITLE
Update auth user type import

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,7 +1,7 @@
 // src/api/auth.ts
 
 import axios from './axios'
-import { User } from '@/types/user'
+import { UserProfile } from '@/types/UserProfile'
 
 const AUTH_BASE = import.meta.env.VITE_AUTHENTIK_BASE_URL
 const CLIENT_ID = import.meta.env.VITE_AUTH_CLIENT_ID
@@ -22,9 +22,9 @@ interface TokenResponse {
 /**
  * Get current authenticated user from backend.
  */
-export async function getCurrentUser(): Promise<User> {
+export async function getCurrentUser(): Promise<UserProfile> {
   try {
-    const res = await axios.get<User>(CURRENT_USER_URL)
+    const res = await axios.get<UserProfile>(CURRENT_USER_URL)
     return res.data
   } catch (err) {
     console.error('[Auth] getCurrentUser error:', err)


### PR DESCRIPTION
## Summary
- update import from `User` to `UserProfile`
- adjust return types accordingly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68701c8d96a8832fbde49ef5fa4d0687

## Summary by Sourcery

Update the authentication API to use the UserProfile type instead of User and adjust related return types accordingly

Enhancements:
- Replace import of User with UserProfile in src/api/auth.ts
- Change getCurrentUser return type and axios generic from User to UserProfile