### PR TITLE
Add zod dependency and test script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^7.6.3",
         "sonner": "^2.0.5",
+        "zod": "^3.22.4",
         "zustand": "^5.0.6"
       },
       "devDependencies": {
@@ -4486,6 +4487,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@stripe/react-stripe-js": "^3.7.0",
@@ -23,7 +24,8 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.6.3",
     "sonner": "^2.0.5",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/src/api/__tests__/users.test.ts
+++ b/src/api/__tests__/users.test.ts
@@ -18,7 +18,7 @@ describe('users.ts', () => {
 
     expect(result?.status).toBe('ok')
     expect(axios.post).toHaveBeenCalledWith(
-      '/api/v1/users/users/avatar',
+      '/users/avatar',
       expect.any(FormData),
       expect.any(Object)
     )
@@ -32,7 +32,7 @@ describe('users.ts', () => {
     ).resolves.not.toThrow()
 
     expect(axios.patch).toHaveBeenCalledWith(
-      '/api/v1/users/users/me',
+      '/users/me',
       expect.objectContaining({ username: 'valid' })
     )
   })
@@ -48,6 +48,6 @@ describe('users.ts', () => {
 
     await expect(deleteAccount()).resolves.not.toThrow()
 
-    expect(axios.delete).toHaveBeenCalledWith('/api/v1/users/users/me')
+    expect(axios.delete).toHaveBeenCalledWith('/users/me')
   })
 })


### PR DESCRIPTION
## Summary
- add zod runtime validation lib
- add `test` script using vitest
- fix API tests for axios base URL

## Testing
- `npx -y vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68726406d358832f85787bb52ef40a0f