### PR TITLE
Fix danger variant buttons in Admin page

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -259,7 +259,7 @@ export default function Admin() {
 
                   <GlassButton
                     size="sm"
-                    variant="destructive"
+                    variant="danger"
                     disabled={loadingId === u.id}
                     onClick={() => handleBanUser(u.id, u.username)}
                     title="Ban user"
@@ -318,7 +318,7 @@ export default function Admin() {
                       </GlassButton>
                       <GlassButton
                         size="sm"
-                        variant="destructive"
+                        variant="danger"
                         onClick={() => handleDeleteFilament(f.id)}
                         disabled={loadingId === f.id}
                       >


### PR DESCRIPTION
## Summary
- use `danger` variant instead of `destructive` for admin actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872668aa2b0832f931b8685479540d4