### PR TITLE
Fix duplicate env lines in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ node_modules
 dist
 dist-ssr
 *.local
-.env
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
@@ -22,5 +21,3 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-.env
-.env


### PR DESCRIPTION
## Summary
- remove redundant `.env` entries in `.gitignore`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687268513e6c832f9ec7bd0e614d39bc