### PR TITLE
Fix auth store path

### DIFF
--- a/src/api/authCallback.ts
+++ b/src/api/authCallback.ts
@@ -1,6 +1,6 @@
 // src/api/authCallback.ts
 import axios from "./axios";
-import { useAuthStore } from "@/stores/authStore";
+import { useAuthStore } from "@/store/useAuthStore";
 
 export async function handleAuthCallback(code: string): Promise<void> {
   const res = await axios.post("/auth/token", { code });


### PR DESCRIPTION
## Summary
- fix auth store import path

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6876990cd514832f8d661e435c010b72

## Summary by Sourcery

Bug Fixes:
- Correct auth store import path from "@/stores/authStore" to "@/store/useAuthStore"