### PR TITLE
Fix user API tests with mock auth token

### DIFF
--- a/src/api/__tests__/users.test.ts
+++ b/src/api/__tests__/users.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import axios from '@/api/axios'
 import { uploadAvatar, updateUserProfile, deleteAccount } from '../users'
+import { useAuthStore } from '@/store/useAuthStore'
 
 vi.mock('@/api/axios')
 
 beforeEach(() => {
   vi.resetAllMocks()
+  useAuthStore.setState({ token: 'testtoken' })
 })
 
 describe('users.ts', () => {
@@ -33,7 +35,10 @@ describe('users.ts', () => {
 
     expect(axios.patch).toHaveBeenCalledWith(
       '/users/me',
-      expect.objectContaining({ username: 'valid' })
+      expect.objectContaining({ username: 'valid' }),
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer testtoken' }
+      })
     )
   })
 
@@ -48,6 +53,11 @@ describe('users.ts', () => {
 
     await expect(deleteAccount()).resolves.not.toThrow()
 
-    expect(axios.delete).toHaveBeenCalledWith('/users/me')
+    expect(axios.delete).toHaveBeenCalledWith(
+      '/users/me',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer testtoken' }
+      })
+    )
   })
 })


### PR DESCRIPTION
## Summary
- reset auth token before each user API test
- check axios calls include authorization headers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687699f5dccc832fa725d73c8b0be840