### PR TITLE
Add Authentik env vars to example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,29 @@
+# Base URL for MakerWorks backend API
 VITE_API_BASE_URL=http://localhost:3000
+
+# Stripe publishable key used during checkout
 VITE_STRIPE_PUBLISHABLE_KEY=pk_test_yourkeyhere
+
+# Base URL of your Authentik instance
+VITE_AUTHENTIK_BASE_URL=https://auth.example.com
+
+# OAuth client ID provided by Authentik
+VITE_AUTH_CLIENT_ID=your-client-id
+
+# OAuth client secret associated with the client ID
+VITE_AUTH_CLIENT_SECRET=your-client-secret
+
+# Redirect URI configured in Authentik for this app
+VITE_AUTHENTIK_REDIRECT_URI=http://localhost:5173/auth/callback
+
+# URL used to initiate the Authentik login flow
+VITE_AUTHENTIK_LOGIN_URL=https://auth.example.com/application/o/authorize/
+
+# URL to Authentik's registration flow
+VITE_AUTHENTIK_REGISTER_URL=https://auth.example.com/if/flow/default-registration/
+
+# Logout endpoint of your Authentik instance
+VITE_AUTHENTIK_LOGOUT_URL=https://auth.example.com/if/session-end/
+
+# Optional override for the Authentik registration path
+VITE_AUTHENTIK_REGISTER_PATH=/if/flow/default-registration/


### PR DESCRIPTION
## Summary
- document Authentik-related variables in `.env.example`

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68769ac01e7c832fb8d7fb7872aeffdf