### PR TITLE
Add Authentik env placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,9 @@
 VITE_API_BASE_URL=http://localhost:3000
 VITE_STRIPE_PUBLISHABLE_KEY=pk_test_yourkeyhere
+VITE_AUTHENTIK_BASE_URL=https://auth.example.com
+VITE_AUTHENTIK_CLIENT_ID=your-client-id
+VITE_AUTHENTIK_CLIENT_SECRET=your-client-secret
+VITE_AUTHENTIK_REDIRECT_URI=http://localhost:5173/auth/callback
+VITE_AUTHENTIK_LOGIN_URL=https://auth.example.com/login/
+VITE_AUTHENTIK_REGISTER_URL=https://auth.example.com/register/
+VITE_AUTHENTIK_LOGOUT_URL=https://auth.example.com/logout/


### PR DESCRIPTION
## Summary
- add Authentik environment variable placeholders to `.env.example`

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879269ad358832fa0e5935f692543c8

## Summary by Sourcery

Enhancements:
- Add AUTHENTIK_BASE_URL, AUTHENTIK_CLIENT_ID, AUTHENTIK_CLIENT_SECRET, and AUTHENTIK_TENANT_ID placeholders to .env.example