### PR TITLE
Add UserOut type and update auth imports

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,9 +1,9 @@
 import axios from './axios';
 import { useAuthStore } from '@/store/useAuthStore';
-import { User } from '@/types/user';
+import { UserOut } from '@/types/auth';
 
 interface SignInResponse {
-  user: User;
+  user: UserOut;
   token: string;
 }
 
@@ -26,8 +26,8 @@ export async function signUp(payload: { email: string; username: string; passwor
 /**
  * GET /auth/me
  */
-export async function getCurrentUser(): Promise<User> {
-  const res = await axios.get<User>('/auth/me');
+export async function getCurrentUser(): Promise<UserOut> {
+  const res = await axios.get<UserOut>('/auth/me');
   const user = res.data;
   useAuthStore.getState().setUser(user);
   return user;

--- a/src/hooks/useSignIn.ts
+++ b/src/hooks/useSignIn.ts
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import axiosInstance from '@/api/axios';
 import axios, { AxiosError } from 'axios';
 import { useAuthStore } from '@/store/useAuthStore';
-import { UserOut } from '@/types/auth'; // optional: adjust path if needed
+import { UserOut } from '@/types/auth';
 
 interface UseSignInResult {
   emailOrUsername: string;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,7 @@
+import type { UserProfile } from './UserProfile'
+
+/**
+ * User information returned from authentication endpoints.
+ * Mirrors the backend `UserOut` model.
+ */
+export interface UserOut extends UserProfile {}


### PR DESCRIPTION
## Summary
- define `UserOut` interface to represent user info returned from auth API
- reference new `auth` type from hooks and API client

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules & other existing errors)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba46d3b90832fa4e7f1a058e1f3f7