### PR TITLE
Refactor filament API usage

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1,5 +1,15 @@
 import axios from "./axios";
 
+export {
+  fetchAvailableFilaments,
+  addFilament,
+  updateFilament,
+  deleteFilament,
+  type Filament,
+  type NewFilament,
+  type UpdateFilament,
+} from "./filaments";
+
 /**
  * TYPES
  */
@@ -19,21 +29,6 @@ export interface Model {
   description?: string;
 }
 
-export interface Filament {
-  id: string;
-  name: string;
-  type: string;
-  subtype?: string;
-  surface?: string;
-  texture?: string;
-  colorHex?: string;
-  colorName?: string;
-  pricePerKg: number;
-  currency: string;
-  description?: string;
-  is_active?: boolean;
-  is_biodegradable?: boolean;
-}
 
 /**
  * USERS
@@ -122,50 +117,3 @@ export async function updateModel(
   }
 }
 
-/**
- * FILAMENTS
- */
-
-export async function fetchAvailableFilaments(): Promise<Filament[]> {
-  try {
-    const res = await axios.get<Filament[]>("/filaments/");
-    return res.data;
-  } catch (err) {
-    console.error("[Admin] Failed to fetch filaments:", err);
-    throw err;
-  }
-}
-
-export async function addFilament(
-  data: Omit<Filament, "id">
-): Promise<Filament> {
-  try {
-    const res = await axios.post<Filament>("/filaments/", data);
-    return res.data;
-  } catch (err) {
-    console.error("[Admin] Failed to add filament:", err);
-    throw err;
-  }
-}
-
-export async function updateFilament(
-  id: string,
-  data: Partial<Omit<Filament, "id">>
-): Promise<Filament> {
-  try {
-    const res = await axios.put<Filament>(`/filaments/${id}`, data);
-    return res.data;
-  } catch (err) {
-    console.error(`[Admin] Failed to update filament ${id}:`, err);
-    throw err;
-  }
-}
-
-export async function deleteFilament(id: string): Promise<void> {
-  try {
-    await axios.delete(`/filaments/${id}`);
-  } catch (err) {
-    console.error(`[Admin] Failed to delete filament ${id}:`, err);
-    throw err;
-  }
-}

--- a/src/pages/admin/FilamentsTab.tsx
+++ b/src/pages/admin/FilamentsTab.tsx
@@ -7,8 +7,8 @@ import {
   addFilament,
   updateFilament,
   deleteFilament,
-  Filament,
-} from '@/api/admin';
+  type Filament,
+} from '@/api/filaments';
 import { confirmAlert } from 'react-confirm-alert';
 
 export default function FilamentsTab() {


### PR DESCRIPTION
## Summary
- centralize filament API in `src/api/filaments.ts`
- re-export filament helpers from `src/api/admin.ts`
- update admin FilamentsTab imports

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bab195d20832fbdd892c52c5381f4

## Summary by Sourcery

Centralize filament-related API functions and types into a dedicated module and update references accordingly.

Enhancements:
- Move filament CRUD API calls and associated types from admin.ts to src/api/filaments.ts
- Re-export filament helpers from admin.ts to maintain backward compatibility
- Update FilamentsTab to import the Filament type from the new filaments API module