### PR TITLE
Connect cart to checkout

### DIFF
--- a/src/lib/__tests__/checkout.test.ts
+++ b/src/lib/__tests__/checkout.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect, vi } from 'vitest'
+import { handleCartCheckout } from '../checkout'
+
+describe('handleCartCheckout', () => {
+  it('navigates to /checkout', () => {
+    const navigate = vi.fn()
+    handleCartCheckout(navigate)
+    expect(navigate).toHaveBeenCalledWith('/checkout')
+  })
+})

--- a/src/lib/checkout.ts
+++ b/src/lib/checkout.ts
@@ -1,0 +1,5 @@
+import type { NavigateFunction } from 'react-router-dom'
+
+export function handleCartCheckout(navigate: NavigateFunction) {
+  navigate('/checkout')
+}

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -1,4 +1,6 @@
 import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { handleCartCheckout } from '@/lib/checkout'
 import PageLayout from '@/components/layout/PageLayout'
 import GlassCard from '@/components/ui/GlassCard'
 import { useCartStore } from '@/store/useCartStore'
@@ -10,6 +12,7 @@ interface CartItem {
 
 export default function Cart() {
   const { items, removeItem, clearCart } = useCartStore()
+  const navigate = useNavigate()
 
   useEffect(() => {
     console.debug('[Cart] Mounted with items:', items)
@@ -17,7 +20,7 @@ export default function Cart() {
 
   const handleCheckout = () => {
     console.info('[Cart] Proceed to checkout')
-    // TODO: implement actual checkout flow
+    handleCartCheckout(navigate)
   }
 
   return (


### PR DESCRIPTION
## Summary
- implement navigation for cart checkout button
- expose `handleCartCheckout` helper
- test checkout navigation logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687bac017a10832f86886ca78578e82e

## Summary by Sourcery

Connect the cart component to the checkout flow by wiring the checkout button to the /checkout route via a shared helper and verify the behavior with new tests

New Features:
- Enable cart checkout button to navigate to the /checkout route

Enhancements:
- Extract checkout navigation logic into a reusable handleCartCheckout helper

Tests:
- Add unit tests for the checkout navigation logic