### PR TITLE
Add QueryClient instance

### DIFF
--- a/src/api/queryClient.ts
+++ b/src/api/queryClient.ts
@@ -1,0 +1,5 @@
+import { QueryClient } from '@tanstack/react-query'
+
+const queryClient = new QueryClient()
+
+export default queryClient


### PR DESCRIPTION
## Summary
- implement `src/api/queryClient.ts`
- use React Query's `QueryClient` singleton for the app

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_687cd723f574832fbe7a334af14ad9bb

## Summary by Sourcery

New Features:
- Add a new src/api/queryClient.ts exporting a shared QueryClient instance from @tanstack/react-query