### PR TITLE
Switch frontend to cookie sessions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,14 +12,14 @@ function AppContent() {
 }
 
 export default function App() {
-  const token = useAuthStore((s) => s.token);
-  const fetchUser = useAuthStore((s) => s.fetchUser);
+  const user = useAuthStore((s) => s.user)
+  const fetchUser = useAuthStore((s) => s.fetchUser)
 
   useEffect(() => {
-    if (token) {
-      fetchUser();
+    if (!user) {
+      fetchUser()
     }
-  }, [token, fetchUser]);
+  }, [user, fetchUser])
 
   return (
     <>

--- a/src/api/__tests__/users.test.ts
+++ b/src/api/__tests__/users.test.ts
@@ -7,7 +7,7 @@ vi.mock('@/api/axios')
 
 beforeEach(() => {
   vi.resetAllMocks()
-  useAuthStore.setState({ token: 'test-token' } as any)
+  useAuthStore.setState({ user: { id: '1', email: 'e', username: 'u', role: 'user' } } as any)
 })
 
 describe('users.ts', () => {
@@ -20,7 +20,7 @@ describe('users.ts', () => {
 
     expect(result?.status).toBe('ok')
     expect(axios.post).toHaveBeenCalledWith(
-      '/users/avatar',
+      '/api/v1/avatar?user_id=1',
       expect.any(FormData),
       expect.any(Object)
     )
@@ -34,9 +34,8 @@ describe('users.ts', () => {
     ).resolves.not.toThrow()
 
     expect(axios.patch).toHaveBeenCalledWith(
-      '/users/me',
-      expect.objectContaining({ username: 'valid' }),
-      expect.any(Object)
+      '/api/v1/users/me',
+      expect.objectContaining({ username: 'valid' })
     )
   })
 
@@ -51,9 +50,6 @@ describe('users.ts', () => {
 
     await expect(deleteAccount()).resolves.not.toThrow()
 
-    expect(axios.delete).toHaveBeenCalledWith(
-      '/users/me',
-      expect.any(Object)
-    )
+    expect(axios.delete).toHaveBeenCalledWith('/api/v1/users/me')
   })
 })

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,41 +1,42 @@
-import axios from './axios';
-import { useAuthStore } from '@/store/useAuthStore';
-import { UserOut } from '@/types/auth';
+import axios from './axios'
+import { useAuthStore } from '@/store/useAuthStore'
+import { UserOut } from '@/types/auth'
 
 interface SignInResponse {
-  user: UserOut;
-  token: string;
+  user: UserOut
+  // optional session token if backend returns one
+  token?: string
 }
 
 /**
  * POST /auth/signin
  */
-export async function signIn(payload: { email_or_username: string; password: string }): Promise<SignInResponse> {
-  const res = await axios.post<SignInResponse>('/auth/signin', payload);
+export async function signIn(
+  payload: { email_or_username: string; password: string }
+): Promise<SignInResponse> {
+  const res = await axios.post<SignInResponse>('/auth/signin', payload)
 
-  const { user, token } = res.data;
+  const { user } = res.data
 
-  // Save token in localStorage for axios interceptor
-  localStorage.setItem('access_token', token);
+  // persist authenticated user in store
+  useAuthStore.getState().setUser(user)
 
-  // Save user in Zustand store
-  useAuthStore.getState().setUser(user);
-
-  return res.data;
+  return res.data
 }
 
 /**
  * POST /auth/signup
  */
-export async function signUp(payload: { email: string; username: string; password: string }): Promise<SignInResponse> {
-  const res = await axios.post<SignInResponse>('/auth/signup', payload);
+export async function signUp(
+  payload: { email: string; username: string; password: string }
+): Promise<SignInResponse> {
+  const res = await axios.post<SignInResponse>('/auth/signup', payload)
 
-  const { user, token } = res.data;
+  const { user } = res.data
 
-  localStorage.setItem('access_token', token);
-  useAuthStore.getState().setUser(user);
+  useAuthStore.getState().setUser(user)
 
-  return res.data;
+  return res.data
 }
 
 /**
@@ -49,10 +50,9 @@ export async function getCurrentUser(): Promise<UserOut> {
 }
 
 /**
- * Local logout — clears state & token.
+ * Local logout — clears auth state.
  * Optional: also call /auth/signout if backend supports it.
  */
 export function logout() {
-  localStorage.removeItem('access_token');
-  useAuthStore.getState().logout();
+  useAuthStore.getState().logout()
 }

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,5 +1,4 @@
-import axios, { AxiosRequestConfig } from 'axios';
-import { useAuthStore } from '@/store/useAuthStore';
+import axios from 'axios'
 
 // ensure baseURL has no trailing slash
 const base =
@@ -8,21 +7,6 @@ const base =
 const instance = axios.create({
   baseURL: base,
   withCredentials: true,
-});
-
-instance.interceptors.request.use((config: AxiosRequestConfig) => {
-  try {
-    const token = useAuthStore.getState().token;
-    if (token) {
-      config.headers = {
-        ...config.headers,
-        Authorization: `Bearer ${token}`,
-      };
-    }
-  } catch (err) {
-    console.warn('[axios] Could not get token from store:', err);
-  }
-  return config;
-});
+})
 
 export default instance;

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -25,8 +25,8 @@ export type UpdateProfilePayload = z.infer<typeof UpdateProfileSchema>
 export const uploadAvatar = async (
   file: File
 ): Promise<AvatarUploadResponse | null> => {
-  const { token, user } = useAuthStore.getState()
-  if (!token || !user?.id) {
+  const { user } = useAuthStore.getState()
+  if (!user?.id) {
     toast.error('❌ Not authenticated. Please log in.')
     return null
   }
@@ -41,7 +41,6 @@ export const uploadAvatar = async (
       {
         headers: {
           'Content-Type': 'multipart/form-data',
-          Authorization: `Bearer ${token}`
         }
       }
     )
@@ -63,8 +62,8 @@ export const uploadAvatar = async (
 export const updateUserProfile = async (
   data: UpdateProfilePayload
 ): Promise<void> => {
-  const token = useAuthStore.getState().token
-  if (!token) {
+  const { user } = useAuthStore.getState()
+  if (!user) {
     toast.error('❌ Not authenticated. Please log in.')
     throw new Error('Not authenticated')
   }
@@ -77,11 +76,7 @@ export const updateUserProfile = async (
   }
 
   try {
-    await axios.patch('/api/v1/users/me', parsed.data, {
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
-    })
+    await axios.patch('/api/v1/users/me', parsed.data)
 
     toast.success('✅ Profile updated.')
   } catch (err: any) {
@@ -97,18 +92,14 @@ export const updateUserProfile = async (
  * Delete the current user's account.
  */
 export const deleteAccount = async (): Promise<void> => {
-  const token = useAuthStore.getState().token
-  if (!token) {
+  const { user } = useAuthStore.getState()
+  if (!user) {
     toast.error('❌ Not authenticated. Please log in.')
     throw new Error('Not authenticated')
   }
 
   try {
-    await axios.delete('/api/v1/users/me', {
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
-    })
+    await axios.delete('/api/v1/users/me')
 
     toast.success('✅ Account deleted.')
   } catch (err: any) {

--- a/src/hooks/useSignIn.ts
+++ b/src/hooks/useSignIn.ts
@@ -3,14 +3,18 @@ import { useNavigate } from 'react-router-dom';
 import axios, { isAxiosError } from 'axios';
 import axiosInstance from '@/api/axios';
 import { useAuthStore } from '@/store/useAuthStore';
-import type { SigninResponse, UserOut } from '@/types/auth';
+import type { UserOut } from '@/types/auth';
+
+interface SigninResponse {
+  user: UserOut
+  token?: string // optional session token
+}
 
 export const useSignIn = () => {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
 
   const navigate = useNavigate();
-  const setToken = useAuthStore((s) => s.setToken);
   const setUser = useAuthStore((s) => s.setUser);
 
   const signIn = async (emailOrUsername: string, password: string) => {
@@ -27,13 +31,13 @@ export const useSignIn = () => {
         password,
       });
 
-      const { user, token } = res.data;
+      const { user } = res.data;
 
-      if (!user || !token) {
-        throw new Error('Invalid response: missing user or token');
+      if (!user) {
+        throw new Error('Invalid response: missing user');
       }
 
-      console.info('[useSignIn] Login successful:', { user, token });
+      console.info('[useSignIn] Login successful:', { user });
 
       // Store avatar path locally (optional, based on your app logic)
       const avatarPath = `/avatars/${user.id}.png`;
@@ -44,7 +48,6 @@ export const useSignIn = () => {
         avatar_url: avatarPath,
       };
 
-      setToken(token);
       setUser(userWithAvatar);
 
       navigate('/dashboard');

--- a/src/hooks/useSignUp.ts
+++ b/src/hooks/useSignUp.ts
@@ -21,7 +21,7 @@ type UseSignUpResult = {
 
 type SignupResponse = {
   user: UserOut;
-  token: string;
+  token?: string; // optional session token
 };
 
 export const useSignUp = (): UseSignUpResult => {
@@ -33,7 +33,6 @@ export const useSignUp = (): UseSignUpResult => {
 
   const navigate = useNavigate();
   const setUser = useAuthStore((s) => s.setUser);
-  const setToken = useAuthStore((s) => s.setToken);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -66,13 +65,12 @@ export const useSignUp = (): UseSignUpResult => {
 
       console.debug('[useSignUp] Response:', res);
 
-      const { user, token } = res.data;
+      const { user } = res.data;
 
-      if (!user || !token) {
-        throw new Error('Invalid response: missing user or token');
+      if (!user) {
+        throw new Error('Invalid response: missing user');
       }
 
-      setToken(token);
       setUser(user);
 
       console.info('[useSignUp] User registered & state updated', user);

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -6,7 +6,7 @@ import { useDevModeStore } from '@/store/useDevModeStore';
 
 
 const Landing: React.FC = () => {
-  const resolved = useAuthStore((s) => !!s.user || !!s.token);
+  const resolved = useAuthStore((s) => !!s.user);
   const loading = false; // you can replace with proper loading state if desired
   const fetchUser = useAuthStore((s) => s.fetchUser);
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -10,11 +10,10 @@ export default function LoginPage() {
   const handleLogin = async () => {
     setLoading(true);
     try {
-      const res = await axios.post('/auth/token', {
+      await axios.post('/auth/token', {
         username,
         password,
-      });
-      localStorage.setItem('access_token', res.data.access_token);
+      })
       toast.success('✅ Login successful');
     } catch (err) {
       console.error(err);

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -61,8 +61,8 @@ const UploadPage: React.FC = () => {
    */
   const uploadAvatarWithProgress = async (file: File) => {
     return new Promise((resolve, reject) => {
-      const { token, user } = require('@/store/useAuthStore').useAuthStore.getState();
-      if (!token || !user?.id) {
+      const { user } = require('@/store/useAuthStore').useAuthStore.getState();
+      if (!user?.id) {
         toast.error('❌ Not authenticated. Please log in.');
         reject(new Error('Not authenticated'));
         return;
@@ -80,7 +80,6 @@ const UploadPage: React.FC = () => {
           {
             headers: {
               'Content-Type': 'multipart/form-data',
-              Authorization: `Bearer ${token}`,
             },
             onUploadProgress: (e: ProgressEvent) => {
               if (e.total) {

--- a/src/store/__tests__/useAuthStore.test.ts
+++ b/src/store/__tests__/useAuthStore.test.ts
@@ -27,16 +27,14 @@ describe('useAuthStore.logout', () => {
     vi.resetModules()
     vi.stubGlobal('localStorage', createLocalStorageMock())
     ;({ useAuthStore } = await import('../useAuthStore'))
-    useAuthStore.setState({ token: 'abc', user: { id: '1', email: 'e', username: 'u', role: 'user' } })
+    useAuthStore.setState({ user: { id: '1', email: 'e', username: 'u', role: 'user' } })
   })
 
   it('clears auth-storage without stray keys', () => {
     const before = localStorage.getItem('auth-store')
     expect(before).toBeTruthy()
     useAuthStore.getState().logout()
-    expect(localStorage.getItem('token')).toBeNull()
     const persisted = JSON.parse(localStorage.getItem('auth-store') || '{}')
-    expect(persisted.state.token).toBeNull()
     expect(persisted.state.user).toBeNull()
     expect(localStorage.length).toBe(1)
     expect(localStorage.key(0)).toBe('auth-store')

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -7,13 +7,10 @@ import type { UserOut } from '@/types/auth';
 type User = UserOut;
 
 interface AuthState {
-  token: string | null;
-  refreshToken: string | null;
   user: User | null;
   loading: boolean;
   resolved: boolean;
 
-  setToken: (token: string, refreshToken: string) => void;
   setUser: (user: User | null) => void;
   setResolved: (val: boolean) => void;
   logout: () => void;
@@ -25,15 +22,10 @@ interface AuthState {
 export const useAuthStore = create<AuthState>()(
   persist(
     (set, get) => ({
-      token: null,
-      refreshToken: null,
       user: null,
       loading: false,
       resolved: false,
 
-      setToken: (token, refreshToken) => {
-        set({ token, refreshToken });
-      },
 
       setUser: (user) => {
         set({ user });
@@ -49,7 +41,7 @@ export const useAuthStore = create<AuthState>()(
       },
 
       logout: () => {
-        set({ token: null, refreshToken: null, user: null, loading: false, resolved: false });
+        set({ user: null, loading: false, resolved: false })
         localStorage.removeItem('avatar_url');
         toast.info('You have been signed out.');
       },
@@ -84,8 +76,8 @@ export const useAuthStore = create<AuthState>()(
       },
 
       isAuthenticated: () => {
-        const state = get();
-        return !!state.token && !!state.user && state.user.role !== 'guest';
+        const state = get()
+        return !!state.user && state.user.role !== 'guest'
       },
 
       hasRole: (role: string) => {


### PR DESCRIPTION
## Summary
- stop storing JWTs on the client and rely on cookie sessions
- remove Authorization header logic
- update auth store and auth hooks for new flow
- adjust pages and API tests accordingly

## Testing
- `npm install`
- `npx vitest run` *(fails: Cannot find package '@testing-library/react')*

------
https://chatgpt.com/codex/tasks/task_e_6880978f9680832fae700258e2d711e5

## Summary by Sourcery

Migrate client authentication to cookie-based sessions by removing client-side JWT storage and authorization headers, simplifying the auth store to track only user state, and updating related API calls, hooks, components, and tests to rely on cookies.

Enhancements:
- Switch signIn and signUp flows to set user state only and drop token handling
- Remove JWT storage, axios interceptor, and Authorization headers from API requests
- Simplify auth store by removing token and refreshToken fields and keeping only user state
- Update frontend components (App, Login, Upload, Landing) to remove token checks and use user store for auth
- Adjust user API endpoints to drop custom headers and correct URL paths

Tests:
- Refactor tests to set and assert user state instead of tokens and update endpoint expectations