### PR TITLE
Add groups field to UserProfile

### DIFF
--- a/src/types/UserProfile.ts
+++ b/src/types/UserProfile.ts
@@ -20,6 +20,9 @@ export interface UserProfile {
   /** Role of the user (usually 'user' or 'admin') */
   role: 'user' | 'admin' | string
 
+  /** Optional groups or roles the user belongs to */
+  groups?: string[]
+
   /** URL to the avatar image */
   avatar_url?: string
 


### PR DESCRIPTION
## Summary
- expand `UserProfile` type with optional `groups: string[]`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688278cae790832fbae4a9e46ae0d533