### PR TITLE
Add vite client types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "baseUrl": "./src",
+    "types": ["vite/client"],
     "paths": {
       "@/*": ["*"]
     }


### PR DESCRIPTION
## Summary
- make sure `import.meta.env` types are available by adding `vite/client` to `compilerOptions.types`

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_688279854ec8832f93ad2652bd7719c5