### PR TITLE
Remove /api/v1 prefix from API paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Backend API base URL
-VITE_API_BASE_URL=http://localhost:8000/api/v1
+VITE_API_BASE_URL=http://localhost:8000
 
 # Optional Stripe (if frontend displays publishable key anywhere)
 VITE_STRIPE_PUBLISHABLE_KEY=pk_test_yourkeyhere

--- a/cypress/e2e/auth_flow.cy.ts
+++ b/cypress/e2e/auth_flow.cy.ts
@@ -22,7 +22,7 @@ describe('MakerWorks Authentik OAuth2 Flow', () => {
   it('✅ Successful login and redirects to dashboard', () => {
     localStorage.setItem('auth_state', mockState);
 
-    cy.intercept('POST', '/api/v1/auth/token', {
+    cy.intercept('POST', '/auth/token', {
       statusCode: 200,
       body: {
         token: 'fake-jwt',
@@ -75,7 +75,7 @@ describe('MakerWorks Authentik OAuth2 Flow', () => {
   it('❌ Fails when backend token exchange fails', () => {
     localStorage.setItem('auth_state', mockState);
 
-    cy.intercept('POST', '/api/v1/auth/token', {
+    cy.intercept('POST', '/auth/token', {
       statusCode: 500,
     }).as('tokenExchange');
 

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -3,9 +3,9 @@
 import axios from 'axios'
 import { useAuthStore } from '@/store/useAuthStore'
 
-// Ensure baseURL has no trailing slash, then append /api/v1
+// Ensure baseURL has no trailing slash
 const base =
-  (import.meta.env.VITE_API_BASE_URL?.replace(/\/+$/, '') || 'http://localhost:8000') + '/api/v1'
+  import.meta.env.VITE_API_BASE_URL?.replace(/\/+$/, '') || 'http://localhost:8000'
 
 const instance = axios.create({
   baseURL: base,

--- a/src/components/settings/AccountSection.tsx
+++ b/src/components/settings/AccountSection.tsx
@@ -15,7 +15,7 @@ export default function AccountSection() {
 
     setDeleting(true)
     try {
-      await axios.delete(`/api/v1/users/${user?.id}`)
+      await axios.delete(`/users/${user?.id}`)
       toast.success('🗑️ Account deleted')
       logout()
     } catch (err) {

--- a/src/components/ui/FilamentFanoutPicker.tsx
+++ b/src/components/ui/FilamentFanoutPicker.tsx
@@ -44,7 +44,7 @@ export default function FilamentFanoutPicker() {
   }
 
   useEffect(() => {
-    axios.get('/api/v1/filaments').then((res) => setFilaments(res.data))
+    axios.get('/filaments').then((res) => setFilaments(res.data))
   }, [])
 
   const categories = Array.from(new Set(filaments.map((f) => f.category)))

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -38,7 +38,7 @@ export const useUser = () => {
 
       if (u.id) {
         try {
-          const uploadsRes = await axios.get(`/api/v1/users/${u.id}/uploads`)
+          const uploadsRes = await axios.get(`/users/${u.id}/uploads`)
           const uploads: Upload[] = uploadsRes.data?.models ?? []
           u.uploads = uploads.sort(
             (a, b) =>

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -58,7 +58,7 @@ const UploadPage: React.FC = () => {
     const formData = new FormData()
     formData.append('file', file)
 
-    return axios.post(`/api/v1/upload`, formData, {
+    return axios.post(`/upload`, formData, {
       headers: {
         'Content-Type': 'multipart/form-data',
         Authorization: `Bearer ${token}`


### PR DESCRIPTION
## Summary
- stop appending `/api/v1` in axios base configuration
- update hardcoded API paths in components and hooks
- remove prefix from Cypress intercepts
- update example environment config

## Testing
- `npm test` *(fails: Failed to resolve import "@/components/ui/MeshLabViewer"...)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6882b84a3988832f82753b19b9927bae

## Summary by Sourcery

Strip the '/api/v1' version prefix from the API base URL and all endpoint calls throughout the application and tests.

Enhancements:
- Remove the '/api/v1' suffix from the axios baseURL configuration and update all hardcoded API paths in components, hooks, and and pages to use unprefixed routes

Documentation:
- Update the example .env configuration to match the new API path conventions

Tests:
- Adjust Cypress intercepts in auth_flow.cy.ts to target endpoints without the '/api/v1' prefix