### PR TITLE
Remove unused backend instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # MakerWorks Frontend
 
-This repository contains the MakerWorks React application built with Vite. A small
-FastAPI service is included under the `backend` folder for local development and tests.
+This repository contains the MakerWorks React application built with Vite.
 
 The project uses the official
 [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc)
@@ -19,15 +18,6 @@ npm install
 
 ```bash
 npm run dev
-```
-
-### Start the FastAPI backend
-
-The backend service is used for authentication tests and local development.
-Run it with:
-
-```bash
-python backend/main.py
 ```
 
 ### Build for production


### PR DESCRIPTION
## Summary
- clean up README and remove references to nonexistent backend directory
- keep only instructions relevant to the frontend

## Testing
- `npm run lint`
- `npm run test` *(fails: Failed to resolve import MeshLabViewer)*

------
https://chatgpt.com/codex/tasks/task_e_6883fe7f16d4832facc7801bec16fb57

## Summary by Sourcery

Remove unused backend instructions from the README and simplify setup guidance to frontend only

Documentation:
- Removed references to the nonexistent backend directory and FastAPI startup commands from the README
- Updated installation and build instructions to focus solely on the frontend setup