### PR TITLE
Fix signin endpoint path

### DIFF
--- a/src/hooks/useSignIn.ts
+++ b/src/hooks/useSignIn.ts
@@ -24,7 +24,7 @@ export const useSignIn = () => {
     setLoading(true)
     try {
       // ✅ Always hit the correct API route
-      const res = await axios.post<SignInResponse>('/api/v1/auth/signin', {
+      const res = await axios.post<SignInResponse>('/auth/signin', {
         email_or_username: emailOrUsername,
         password
       })


### PR DESCRIPTION
## Summary
- use `/auth/signin` path in `useSignIn`
- confirm axios base URL already points to `/api/v1`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884034b04d0832f99284c55d6df2093