### PR TITLE
Fix sign-in endpoint

### DIFF
--- a/src/hooks/useSignIn.ts
+++ b/src/hooks/useSignIn.ts
@@ -23,8 +23,8 @@ export const useSignIn = () => {
   const signIn = async (emailOrUsername: string, password: string) => {
     setLoading(true)
     try {
-      // ✅ Always hit the correct API route
-      const res = await axios.post<SignInResponse>('/api/v1/auth/signin', {
+      // ✅ Always hit the correct API route (base URL already includes /api/v1)
+      const res = await axios.post<SignInResponse>('/auth/signin', {
         email_or_username: emailOrUsername,
         password
       })


### PR DESCRIPTION
## Summary
- update sign-in hook to use `/auth/signin` endpoint
- confirm axios base URL already includes `/api/v1`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688407f7d484832fa4ed5e9df6e26115