### PR TITLE
Remove TanStack Query

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ MakerWorks Frontend is a responsive React application powered by Vite and TypeSc
 - **TypeScript** for type safety
 - **Vite** development server
 - **Tailwind CSS** for styling
-- **TanStack Query** for data fetching and caching
+- **Axios** for HTTP requests
 - **Zod** for schema validation
 - **Framer Motion** animations
 - **Cypress** and **Vitest** for testing

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,6 @@
       "dependencies": {
         "@stripe/react-stripe-js": "^3.7.0",
         "@stripe/stripe-js": "^7.5.0",
-        "@tanstack/react-query": "^5.83.0",
-        "@tanstack/react-query-devtools": "^5.83.0",
         "axios": "^1.10.0",
         "clsx": "^2.1.1",
         "framer-motion": "^12.23.0",
@@ -2111,59 +2109,6 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
-      }
-    },
-    "node_modules/@tanstack/query-core": {
-      "version": "5.83.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.0.tgz",
-      "integrity": "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/query-devtools": {
-      "version": "5.81.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.81.2.tgz",
-      "integrity": "sha512-jCeJcDCwKfoyyBXjXe9+Lo8aTkavygHHsUHAlxQKKaDeyT0qyQNLKl7+UyqYH2dDF6UN/14873IPBHchcsU+Zg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/react-query": {
-      "version": "5.83.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.83.0.tgz",
-      "integrity": "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-core": "5.83.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19"
-      }
-    },
-    "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.83.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.83.0.tgz",
-      "integrity": "sha512-yfp8Uqd3I1jgx8gl0lxbSSESu5y4MO2ThOPBnGNTYs0P+ZFu+E9g5IdOngyUGuo6Uz6Qa7p9TLdZEX3ntik2fQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-devtools": "5.81.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/react-query": "^5.83.0",
-        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
   "dependencies": {
     "@stripe/react-stripe-js": "^3.7.0",
     "@stripe/stripe-js": "^7.5.0",
-    "@tanstack/react-query": "^5.83.0",
-    "@tanstack/react-query-devtools": "^5.83.0",
     "axios": "^1.10.0",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.0",

--- a/src/api/queryClient.ts
+++ b/src/api/queryClient.ts
@@ -1,5 +1,0 @@
-import { QueryClient } from '@tanstack/react-query'
-
-const queryClient = new QueryClient()
-
-export default queryClient

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,15 +1,12 @@
 import React, { StrictMode, Suspense } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
-import { QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { HelmetProvider } from 'react-helmet-async';
 
 import App from '@/App';
 import ErrorBoundary from '@/components/system/ErrorBoundary';
 import { ToastProvider } from '@/context/ToastProvider';
 import { UserProvider } from '@/context/UserContext';
-import queryClient from '@/api/queryClient';
 
 import '@/index.css';
 
@@ -36,20 +33,15 @@ createRoot(rootElement).render(
   <StrictMode>
     <HelmetProvider>
       <BrowserRouter>
-        <QueryClientProvider client={queryClient}>
-          <UserProvider>
-            <ToastProvider>
-              <ErrorBoundary>
-                <Suspense fallback={<div className="loading">🔄 Loading MakerWorks...</div>}>
-                  <App />
-                </Suspense>
-              </ErrorBoundary>
-            </ToastProvider>
-          </UserProvider>
-
-          {/* Only include devtools in development */}
-          {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
-        </QueryClientProvider>
+        <UserProvider>
+          <ToastProvider>
+            <ErrorBoundary>
+              <Suspense fallback={<div className="loading">🔄 Loading MakerWorks...</div>}>
+                <App />
+              </Suspense>
+            </ErrorBoundary>
+          </ToastProvider>
+        </UserProvider>
       </BrowserRouter>
     </HelmetProvider>
   </StrictMode>

--- a/src/store/__tests__/Estimate.test.tsx
+++ b/src/store/__tests__/Estimate.test.tsx
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 expect.extend(matchers);
@@ -20,10 +19,6 @@ vi.mock('@/api/estimate', () => ({
   getEstimate: vi.fn(),
 }));
 
-const renderWithClient = (ui: React.ReactElement) => {
-  const queryClient = new QueryClient();
-  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
-};
 
 describe('<Estimate />', () => {
   beforeEach(() => {
@@ -31,7 +26,7 @@ describe('<Estimate />', () => {
     window.scrollTo = vi.fn();
   });
   it('renders page header', () => {
-    renderWithClient(<Estimate />);
+    render(<Estimate />);
     expect(screen.getByText(/Estimate Print Job/i)).toBeInTheDocument();
   });
 
@@ -39,7 +34,7 @@ describe('<Estimate />', () => {
     (filamentsApi.fetchAvailableFilaments as any).mockResolvedValue([
       { id: '1', type: 'PLA', color: 'Red', hex: '#ff0000' },
     ]);
-    renderWithClient(<Estimate />);
+    render(<Estimate />);
     await waitFor(() => {
       expect(screen.getAllByText(/Select filament/i)[0]).toBeInTheDocument();
     });
@@ -53,7 +48,7 @@ describe('<Estimate />', () => {
       estimated_time_minutes: 30,
       estimated_cost_usd: 10,
     });
-    renderWithClient(<Estimate />);
+    render(<Estimate />);
     await waitFor(() => {
       expect(screen.getAllByText(/Select filament/i)[0]).toBeInTheDocument();
     });


### PR DESCRIPTION
## Summary
- remove TanStack Query deps and query client
- simplify `main.tsx` and tests
- document Axios instead of TanStack Query

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68843108a010832fa12d81efdd90aefb

## Summary by Sourcery

Remove TanStack Query and query client setup, migrate to Axios for data fetching, simplify application bootstrap and tests, and update documentation and dependencies accordingly.

Enhancements:
- Remove QueryClientProvider wrapper and React Query devtools from the app entrypoint
- Simplify component tests by removing the custom renderWithClient and testing components directly

Documentation:
- Update README to document Axios for HTTP requests instead of TanStack Query

Tests:
- Remove QueryClientProvider from tests and adjust renders to use direct component rendering

Chores:
- Remove @tanstack/react-query and @tanstack/react-query-devtools from dependencies
- Delete the queryClient.ts file