### PR TITLE
Add pytest test for image generation

### DIFF
--- a/tests/test_generate_sample_images.py
+++ b/tests/test_generate_sample_images.py
@@ -1,0 +1,14 @@
+import subprocess
+import sys
+from pathlib import Path
+from PIL import Image
+
+
+def test_generate_sample_image(tmp_path):
+    script = Path(__file__).resolve().parent.parent / "generate_sample_images.py"
+    subprocess.run([sys.executable, str(script)], cwd=tmp_path, check=True)
+    out_file = tmp_path / "sample.png"
+    assert out_file.exists(), "sample.png was not created"
+    with Image.open(out_file) as img:
+        assert img.size == (512, 512)
+        assert img.mode == "RGB"


### PR DESCRIPTION
## Summary
- add a pytest test for `generate_sample_images.py`
- install Pillow for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688529f7d238832fa484cd1658f05d0f

## Summary by Sourcery

Tests:
- Add test_generate_sample_images.py to run generate_sample_images.py and verify sample.png exists with a 512×512 size and RGB mode