### PR TITLE
Fix avatar refresh after signin

### DIFF
--- a/src/api/__tests__/users.test.ts
+++ b/src/api/__tests__/users.test.ts
@@ -32,6 +32,7 @@ beforeEach(() => {
   useAuthStore.setState({
     user: { id: '1', email: 'e', username: 'u', role: 'user' } as any,
     token: 'test-token',
+    fetchUser: vi.fn().mockResolvedValue(null)
   })
   ;(axios.get as any).mockResolvedValue({ data: { id: '1', email: 'e' } })
 })
@@ -50,6 +51,7 @@ describe('users.ts', () => {
       expect.any(FormData),
       expect.any(Object)
     )
+    expect(useAuthStore.getState().fetchUser).toHaveBeenCalledWith(true)
   })
 
   it('updates user profile', async () => {

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -26,7 +26,7 @@ export type UpdateProfilePayload = z.infer<typeof UpdateProfileSchema>
 export const uploadAvatar = async (
   file: File
 ): Promise<AvatarUploadResponse | null> => {
-  const { token, user, setUser } = useAuthStore.getState()
+  const { token, user, setUser, fetchUser } = useAuthStore.getState()
   if (!token || !user?.id) {
     toast.error('❌ Not authenticated. Please log in.')
     return null
@@ -52,6 +52,12 @@ export const uploadAvatar = async (
       ...user,
       avatar_url: res.data.avatar_url
     })
+
+    try {
+      await fetchUser(true)
+    } catch (err) {
+      console.warn('[uploadAvatar] Failed to refresh user:', err)
+    }
 
     toast.success('✅ Avatar updated.')
     return res.data

--- a/src/hooks/__tests__/useSignIn.test.tsx
+++ b/src/hooks/__tests__/useSignIn.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import axios from '@/api/axios'
+import { useSignIn } from '../useSignIn'
+import { useAuthStore } from '@/store/useAuthStore'
+
+vi.mock('@/api/axios')
+
+function createStorageMock() {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+    key: (i: number) => Object.keys(store)[i] || null,
+    get length() {
+      return Object.keys(store).length
+    }
+  }
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.stubGlobal('localStorage', createStorageMock())
+  vi.stubGlobal('sessionStorage', createStorageMock())
+  useAuthStore.setState({
+    token: null,
+    user: null,
+    setAuth: vi.fn(),
+    fetchUser: vi.fn().mockResolvedValue(null)
+  })
+})
+
+describe('useSignIn', () => {
+  it('fetches profile after successful sign in', async () => {
+    (axios.post as any).mockResolvedValue({
+      data: {
+        token: 't',
+        user: { id: '1', username: 'u', email: 'e', role: 'user' }
+      }
+    })
+
+    const wrapper = ({ children }: any) => <MemoryRouter>{children}</MemoryRouter>
+    const { result } = renderHook(() => useSignIn(), { wrapper })
+    await act(async () => {
+      await result.current.signIn('u', 'p')
+    })
+
+    expect(useAuthStore.getState().setAuth).toHaveBeenCalledWith({
+      token: 't',
+      user: { id: '1', username: 'u', email: 'e', role: 'user' }
+    })
+    expect(useAuthStore.getState().fetchUser).toHaveBeenCalledWith(true)
+  })
+})

--- a/src/hooks/useSignIn.ts
+++ b/src/hooks/useSignIn.ts
@@ -33,8 +33,15 @@ export const useSignIn = () => {
       if (!token || !user) throw new Error('Invalid response from server')
 
       // ✅ Update Zustand + persist auth state
-      const { setAuth } = useAuthStore.getState()
+      const { setAuth, fetchUser } = useAuthStore.getState()
       setAuth({ token, user })
+
+      // Ensure avatar and other profile details are loaded
+      try {
+        await fetchUser(true)
+      } catch (err) {
+        console.warn('[useSignIn] Failed to fetch full profile:', err)
+      }
 
       toast.success(`Welcome back, ${user.username}!`)
 

--- a/src/store/__tests__/Estimate.test.tsx
+++ b/src/store/__tests__/Estimate.test.tsx
@@ -5,15 +5,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 expect.extend(matchers);
 import Estimate from '../../pages/Estimate';
-import * as filamentsApi from '@/api/filaments';
+import axios from '@/api/axios';
 import * as estimateApi from '@/api/estimate';
 vi.mock('@/components/ui/ModelViewer', () => ({
   default: () => <div data-testid="model-viewer" />,
 }));
 
-vi.mock('@/api/filaments', () => ({
-  fetchAvailableFilaments: vi.fn().mockResolvedValue([]),
-}));
 
 vi.mock('@/api/estimate', () => ({
   getEstimate: vi.fn(),
@@ -31,9 +28,9 @@ describe('<Estimate />', () => {
   });
 
   it('loads filaments and shows success toast', async () => {
-    (filamentsApi.fetchAvailableFilaments as any).mockResolvedValue([
-      { id: '1', type: 'PLA', color: 'Red', hex: '#ff0000' },
-    ]);
+    ;(axios.get as any) = vi.fn().mockResolvedValue({
+      data: [{ id: '1', type: 'PLA', color: 'Red', hex: '#ff0000' }]
+    });
     render(<Estimate />);
     await waitFor(() => {
       expect(screen.getAllByText(/Select filament/i)[0]).toBeInTheDocument();
@@ -41,9 +38,9 @@ describe('<Estimate />', () => {
   });
 
   it.skip('shows estimate when form is filled', async () => {
-    (filamentsApi.fetchAvailableFilaments as any).mockResolvedValue([
-      { id: '1', type: 'PLA', color: 'Red', hex: '#ff0000' },
-    ]);
+    ;(axios.get as any) = vi.fn().mockResolvedValue({
+      data: [{ id: '1', type: 'PLA', color: 'Red', hex: '#ff0000' }]
+    });
     (estimateApi.getEstimate as any).mockResolvedValue({
       estimated_time_minutes: 30,
       estimated_cost_usd: 10,


### PR DESCRIPTION
## Summary
- ensure avatar refresh after sign in by calling `fetchUser`
- refresh user data after uploading a new avatar
- adjust tests for new behaviour
- add test for `useSignIn` hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68856420a18c832f98d91dad40c7d325