### PR TITLE
Fix asset URLs

### DIFF
--- a/src/components/settings/AvatarSection.tsx
+++ b/src/components/settings/AvatarSection.tsx
@@ -3,6 +3,7 @@ import { useRef, useState, useEffect } from 'react';
 import { useAuthStore } from '@/store/useAuthStore';
 import axios from '@/api/axios';
 import { toast } from 'sonner';
+import getAbsoluteUrl from '@/lib/getAbsoluteUrl';
 
 interface AvatarSectionProps {
   currentAvatar?: string;
@@ -20,10 +21,7 @@ export default function AvatarSection({ currentAvatar, onAvatarUpdate }: AvatarS
     }
   }, [user, token, fetchUser]);
 
-  const getAbsoluteUrl = (path?: string | null) => {
-    if (!path) return null;
-    return path.startsWith('http') ? path : `${import.meta.env.VITE_API_URL}${path}`;
-  };
+  // ✅ Safe URL builder from shared util
 
   const cachedAvatar = localStorage.getItem('avatar_url');
   const avatarSrc =

--- a/src/components/ui/GlassNavbar.tsx
+++ b/src/components/ui/GlassNavbar.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 import UserDropdown from '@/components/ui/UserDropdown';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useEffect, useRef } from 'react';
+import getAbsoluteUrl from '@/lib/getAbsoluteUrl';
 
 const GlassNavbar = () => {
   const user = useAuthStore((s) => s.user);
@@ -33,12 +34,7 @@ const GlassNavbar = () => {
     { path: '/checkout', label: 'Checkout' }
   ];
 
-  // ✅ Safe URL builder with fallback
-  const getAbsoluteUrl = (path?: string | null): string | null => {
-    if (!path) return null;
-    const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:8000';
-    return path.startsWith('http') ? path : `${apiBase}${path}`;
-  };
+  // ✅ Safe URL builder from shared util
 
   const fallbackUser = {
     username: 'Guest',

--- a/src/components/ui/UserDashboardCard.tsx
+++ b/src/components/ui/UserDashboardCard.tsx
@@ -2,6 +2,7 @@
 import { useNavigate } from 'react-router-dom';
 import GlassCard from '@/components/ui/GlassCard';
 import { useAuthStore } from '@/store/useAuthStore';
+import getAbsoluteUrl from '@/lib/getAbsoluteUrl';
 
 const UserDashboardCard = () => {
   const navigate = useNavigate();
@@ -10,12 +11,7 @@ const UserDashboardCard = () => {
 
   if (!user) return null;
 
-  // ✅ Safe URL builder with fallback
-  const getAbsoluteUrl = (path?: string | null): string | null => {
-    if (!path) return null;
-    const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:8000';
-    return path.startsWith('http') ? path : `${apiBase}${path}`;
-  };
+  // ✅ Safe URL builder from shared util
 
   // ✅ Ensure avatar URL is always resolved from backend or localStorage
   const cachedAvatar = localStorage.getItem('avatar_url');

--- a/src/components/ui/UserDropdown.tsx
+++ b/src/components/ui/UserDropdown.tsx
@@ -5,6 +5,7 @@ import { useTheme } from '@/hooks/useTheme'
 import { Sun, Moon } from 'lucide-react'
 import axiosInstance from '@/api/axios'
 import { toast } from 'sonner'
+import getAbsoluteUrl from '@/lib/getAbsoluteUrl'
 import type { UserProfile } from '@/types/UserProfile'
 
 type Props = {
@@ -48,8 +49,6 @@ const UserDropdown = ({ user }: Props) => {
     setTheme(isDark ? 'light' : 'dark')
   }
 
-  const getAbsoluteUrl = (path?: string | null) =>
-    path?.startsWith('http') ? path : `${import.meta.env.VITE_API_URL}${path}`
 
   const resolvedUser: UserProfile = {
     username: user.username || 'Guest',

--- a/src/lib/getAbsoluteUrl.ts
+++ b/src/lib/getAbsoluteUrl.ts
@@ -1,0 +1,6 @@
+export default function getAbsoluteUrl(path?: string | null): string | null {
+  if (!path) return null;
+  const base =
+    import.meta.env.VITE_API_BASE_URL?.replace(/\/+$/, '') || 'http://localhost:8000';
+  return path.startsWith('http') ? path : `${base}${path}`;
+}

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -4,6 +4,7 @@ import axios from '@/api/axios';
 import GlassCard from '@/components/ui/GlassCard';
 import PageHeader from '@/components/ui/PageHeader';
 import { Search } from 'lucide-react';
+import getAbsoluteUrl from '@/lib/getAbsoluteUrl';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useToast } from '@/context/ToastProvider';
 
@@ -196,7 +197,7 @@ const Browse: React.FC = () => {
                   {model.thumbnail_url ? (
                     <img
                       key={`thumb-${model.id}`}
-                      src={model.thumbnail_url}
+                      src={getAbsoluteUrl(model.thumbnail_url) || model.thumbnail_url}
                       alt={model.name ?? 'Model'}
                       className="rounded-md mb-2 w-full h-40 object-cover"
                     />

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -5,18 +5,14 @@ import ProfileSection from '@/components/settings/ProfileSection';
 import AccountSection from '@/components/settings/AccountSection';
 import ThemeSection from '@/components/settings/ThemeSection';
 import { useAuthStore } from '@/store/useAuthStore';
+import getAbsoluteUrl from '@/lib/getAbsoluteUrl';
 
 export default function Settings() {
   const [activeTab, setActiveTab] = useState<'profile' | 'account' | 'avatar' | 'theme'>('profile');
   const user = useAuthStore((s) => s.user);
   const setUser = useAuthStore((s) => s.setUser);
 
-  // ✅ Safe URL builder with fallback to avoid undefined/uploads
-  const getAbsoluteUrl = (path?: string | null): string | null => {
-    if (!path) return null;
-    const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:8000';
-    return path.startsWith('http') ? path : `${apiBase}${path}`;
-  };
+  // ✅ Safe URL builder from shared util
 
   const cachedAvatar = localStorage.getItem('avatar_url');
   const avatarSrc =


### PR DESCRIPTION
## Summary
- add shared `getAbsoluteUrl` helper
- use helper everywhere avatars and thumbnails are resolved
- adjust Browse page to handle thumbnail URLs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688691dde54c832f92b124eff066b9a9