### PR TITLE
Fix thumbnail URL in Browse page

### DIFF
--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -182,9 +182,8 @@ const Browse: React.FC = () => {
               filteredModels.map((model) => {
                 const modelKey = model.id || model.file_url || Math.random().toString();
                 // ✅ Use full backend URL without normalization
-                const thumbUrl = model.thumbnail_url
-                ? getAbsoluteUrl(`/uploads/thumbnails/${model.thumbnail_url.split('/').pop()}`)
-                : null;
+                // Build thumbnail URL using the helper directly
+                const thumbUrl = getAbsoluteUrl(model.thumbnail_url);
 
                 return (
                   <GlassCard


### PR DESCRIPTION
## Summary
- fix incorrect thumbnail path in Browse page

## Testing
- `npm run lint`
- `npm test` *(fails: 1 unhandled network error)*

------
https://chatgpt.com/codex/tasks/task_e_688bb52dac34832fbc69b6719a0484ac

## Summary by Sourcery

Bug Fixes:
- Generate thumbnail URLs with getAbsoluteUrl(model.thumbnail_url) instead of manually reconstructing the path